### PR TITLE
fix bug in band pass filter limits

### DIFF
--- a/app.py
+++ b/app.py
@@ -113,11 +113,11 @@ detector = st.sidebar.selectbox('Detector', detectorlist)
 
 # -- Select for high sample rate data
 fs = 4096
-maxband = 2000
+maxband = 1200
 high_fs = st.sidebar.checkbox('Full sample rate data')
 if high_fs:
     fs = 16384
-    maxband = 8000
+    maxband = 2000
 
 
 # -- Create sidebar for plot controls


### PR DESCRIPTION
I noticed the app log showed errors related to band-pass filtering.

I was able to reproduce the error by using a band-pass filter with a cut-off frequency near Nyquist.  I fixed it by setting a stricter limit on the band-pass limits.