### PR TITLE
Fix gwosc.org URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Gravitational Wave Quickview App
 
-This app downloads and displays a few seconds of data from the [Gravitational Wave Open Science Center](https://gw-osc.org).
+This app downloads and displays a few seconds of data from the [Gravitational Wave Open Science Center](https://gwosc.org).
 
 [![Open in Streamlit](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://share.streamlit.io/jkanner/streamlit-dataview/app.py)

--- a/app.py
+++ b/app.py
@@ -101,7 +101,7 @@ else:
             st.write('Mass 1:', nameinfo['mass_1_source'], 'M$_{\odot}$')
             st.write('Mass 2:', nameinfo['mass_2_source'], 'M$_{\odot}$')
             st.write('Network SNR:', int(nameinfo['network_matched_filter_snr']))
-            eventurl = 'https://gw-osc.org/eventapi/html/event/{}'.format(chosen_event)
+            eventurl = 'https://gwosc.org/eventapi/html/event/{}'.format(chosen_event)
             st.markdown('Event page: {}'.format(eventurl))
             st.write('\n')
     except:


### PR DESCRIPTION
In two places it was gw-osc.org instead of gwosc.org