### PR TITLE
Correct link to GWpy's q-transform page

### DIFF
--- a/app.py
+++ b/app.py
@@ -233,7 +233,7 @@ For gravitational-wave signals, binary black holes are most clear with lower Q v
 
 See also:
 
- * [GWpy q-transform](https://gwpy.github.io/docs/stable/examples/timeseries/qscan.html)
+ * [GWpy q-transform](https://gwpy.github.io/docs/latest/examples/timeseries/qscan/)
  * [Reading Time-frequency plots](https://labcit.ligo.caltech.edu/~jkanner/aapt/web/math.html#tfplot)
  * [Shourov Chatterji PhD Thesis](https://dspace.mit.edu/handle/1721.1/34388)
 """)


### PR DESCRIPTION
This PR corrects a link to GWpy documentation (see https://git.ligo.org/gwosc/gwoscweb/-/issues/848).